### PR TITLE
Fix stampede protection to actually work, not only delayed stampede

### DIFF
--- a/HzMemoryCache/HzMemoryCache.cs
+++ b/HzMemoryCache/HzMemoryCache.cs
@@ -164,7 +164,8 @@ namespace HzCache
 
             try
             {
-                if ((value = Get<T>(key)) is not null)
+                value = Get<T>(key);
+                if (!IsNullOrDefault(value))
                 {
                     return value;
                 }

--- a/HzMemoryCache/HzMemoryCache.cs
+++ b/HzMemoryCache/HzMemoryCache.cs
@@ -164,6 +164,10 @@ namespace HzCache
 
             try
             {
+                if ((value = Get<T>(key)) is not null)
+                {
+                    return value;
+                }
                 value = valueFactory(key);
                 var ttlValue = new TTLValue(key, value, ttl, updateChecksumAndSerializeQueue, options.notificationType, (tv, objectData) =>
                 {

--- a/HzMemoryCache/HzMemoryCacheAsync.cs
+++ b/HzMemoryCache/HzMemoryCacheAsync.cs
@@ -41,6 +41,10 @@ namespace HzCache
 
             try
             {
+                if ((value = Get<T>(key)) is not null)
+                {
+                    return value;
+                }
                 value = await valueFactory(key);
                 var ttlValue = new TTLValue(key, value, ttl, updateChecksumAndSerializeQueue, options.notificationType, (tv, objectData) =>
                 {

--- a/HzMemoryCache/HzMemoryCacheAsync.cs
+++ b/HzMemoryCache/HzMemoryCacheAsync.cs
@@ -41,7 +41,8 @@ namespace HzCache
 
             try
             {
-                if ((value = Get<T>(key)) is not null)
+                value = Get<T>(key);
+                if (!IsNullOrDefault(value))
                 {
                     return value;
                 }


### PR DESCRIPTION
Fix the extremely embarrasing problem that factory method is always called, making the stampede protection more or less pointless.