### PR TITLE
Hotfix/handle default primitives

### DIFF
--- a/HzMemoryCache/HzMemoryCache.cs
+++ b/HzMemoryCache/HzMemoryCache.cs
@@ -164,7 +164,8 @@ namespace HzCache
 
             try
             {
-                if ((value = Get<T>(key)) is not null)
+                value = Get<T>(key);
+                if (!IsNullOrDefault(value))
                 {
                     return value;
                 }

--- a/HzMemoryCache/HzMemoryCache.cs
+++ b/HzMemoryCache/HzMemoryCache.cs
@@ -164,6 +164,10 @@ namespace HzCache
 
             try
             {
+                if ((value = Get<T>(key)) is not null)
+                {
+                    return value;
+                }
                 value = valueFactory(key);
                 var ttlValue = new TTLValue(key, value, ttl, updateChecksumAndSerializeQueue, options.notificationType, (tv, objectData) =>
                 {

--- a/HzMemoryCache/HzMemoryCacheAsync.cs
+++ b/HzMemoryCache/HzMemoryCacheAsync.cs
@@ -41,6 +41,10 @@ namespace HzCache
 
             try
             {
+                if ((value = Get<T>(key)) is not null)
+                {
+                    return value;
+                }
                 value = await valueFactory(key);
                 var ttlValue = new TTLValue(key, value, ttl, updateChecksumAndSerializeQueue, options.notificationType, (tv, objectData) =>
                 {

--- a/HzMemoryCache/HzMemoryCacheAsync.cs
+++ b/HzMemoryCache/HzMemoryCacheAsync.cs
@@ -41,13 +41,15 @@ namespace HzCache
 
             try
             {
-                value = Get<T>(key);
-                if (!IsNullOrDefault(value))
+                if (TryGetUpdateTimeToKill(key, out TTLValue ttlValue))
                 {
-                    return value;
+                    if (ttlValue.value is T o)
+                    {
+                        return o;
+                    }
                 }
                 value = await valueFactory(key);
-                var ttlValue = new TTLValue(key, value, ttl, updateChecksumAndSerializeQueue, options.notificationType, (tv, objectData) =>
+                ttlValue = new TTLValue(key, value, ttl, updateChecksumAndSerializeQueue, options.notificationType, (tv, objectData) =>
                 {
                     NotifyItemChange(key, CacheItemChangeType.AddOrUpdate, tv, objectData);
                 });

--- a/HzMemoryCache/HzMemoryCacheAsync.cs
+++ b/HzMemoryCache/HzMemoryCacheAsync.cs
@@ -41,7 +41,8 @@ namespace HzCache
 
             try
             {
-                if ((value = Get<T>(key)) is not null)
+                value = Get<T>(key);
+                if (!IsNullOrDefault(value))
                 {
                     return value;
                 }

--- a/UnitTests/UnitTests.cs
+++ b/UnitTests/UnitTests.cs
@@ -170,25 +170,22 @@ namespace UnitTests
             Assert.IsTrue(result == 42);
         }
 
-        /// <summary>
-        /// This test fails, it's not supported to handle that the default primitive value is cached.
-        /// </summary>
         [TestMethod]
         public async Task TestZeroIntFactoryCall()
         {
-            // var cache = new HzMemoryCache();
-            // cache.GetOrSet("0", v => 0, TimeSpan.FromMilliseconds(500000));
-            //
-            // await Task.Delay(50);
-            // cache.GetOrSet("0", v =>
-            // {
-            //     Assert.Fail("Shouldn't be called!");
-            //     return 0;
-            // }, TimeSpan.FromMilliseconds(500000));
-            //
-            // var result = cache.Get<int>("42");
-            // Assert.IsNotNull(result); //not evicted
-            // Assert.IsTrue(result == 0);
+            var cache = new HzMemoryCache();
+            cache.GetOrSet("0", v => 0, TimeSpan.FromMilliseconds(500000));
+            
+            await Task.Delay(50);
+            cache.GetOrSet("0", v =>
+            {
+                Assert.Fail("Shouldn't be called!");
+                return 0;
+            }, TimeSpan.FromMilliseconds(500000));
+            
+            var result = cache.Get<int>("42");
+            Assert.IsNotNull(result); //not evicted
+            Assert.IsTrue(result == 0);
         }
 
         [TestMethod]


### PR DESCRIPTION
Handle caching of default primitives better - preventing factory method to call everytime if a default primitive (like `0` for `int` is stored in cache).