### PR TITLE
PROD-5987: fix race condition in HzCacheMemoryLocker causing disposed semaphore errors

### DIFF
--- a/HzMemoryCache/HzCacheMemoryLocker.cs
+++ b/HzMemoryCache/HzCacheMemoryLocker.cs
@@ -10,6 +10,7 @@ namespace HzCache
     public class HzCacheMemoryLockerOptions
     {
         public int lockPoolSize { get; set; } = 7872;
+        public int maxLockRetries { get; set; } = 3;
     }
 
     public class HzCacheMemoryLocker
@@ -93,17 +94,20 @@ namespace HzCache
             var acquired = false;
             using (var waitForSemaphore = HzActivities.Source.StartActivityWithCommonTags(HzActivities.Names.WaitForSemaphore, HzActivities.Area.HzCacheMemoryLocker, key: key, async: true))
             {
-                try
+                for (var attempt = 0; attempt <= options.maxLockRetries; attempt++)
                 {
-                    acquired = await semaphore.WaitAsync(timeout, token).ConfigureAwait(false);
-                }
-                catch (ObjectDisposedException)
-                {
-                    // The MemoryCache evicted and disposed this semaphore between GetSemaphore and WaitAsync.
-                    // Remove the stale entry and retry with a fresh semaphore.
-                    lockCache.Remove(key);
-                    semaphore = GetSemaphore(cacheName, cacheInstanceId, key, logger);
-                    acquired = await semaphore.WaitAsync(timeout, token).ConfigureAwait(false);
+                    try
+                    {
+                        acquired = await semaphore.WaitAsync(timeout, token).ConfigureAwait(false);
+                        break;
+                    }
+                    catch (ObjectDisposedException) when (attempt < options.maxLockRetries)
+                    {
+                        // The MemoryCache evicted and disposed this semaphore between GetSemaphore and WaitAsync.
+                        // Remove the stale entry and retry with a fresh semaphore.
+                        lockCache.Remove(key);
+                        semaphore = GetSemaphore(cacheName, cacheInstanceId, key, logger);
+                    }
                 }
             }
 
@@ -147,15 +151,18 @@ namespace HzCache
                    HzActivities.Source.StartActivityWithCommonTags(HzActivities.Names.WaitForSemaphore,
                        HzActivities.Area.HzCacheMemoryLocker, key: key))
             {
-                try
+                for (var attempt = 0; attempt <= options.maxLockRetries; attempt++)
                 {
-                    acquired = semaphore.Wait(timeout, token);
-                }
-                catch (ObjectDisposedException)
-                {
-                    lockCache.Remove(key);
-                    semaphore = GetSemaphore(cacheName, cacheInstanceId, key, logger);
-                    acquired = semaphore.Wait(timeout, token);
+                    try
+                    {
+                        acquired = semaphore.Wait(timeout, token);
+                        break;
+                    }
+                    catch (ObjectDisposedException) when (attempt < options.maxLockRetries)
+                    {
+                        lockCache.Remove(key);
+                        semaphore = GetSemaphore(cacheName, cacheInstanceId, key, logger);
+                    }
                 }
             }
 

--- a/HzMemoryCache/HzCacheMemoryLocker.cs
+++ b/HzMemoryCache/HzCacheMemoryLocker.cs
@@ -93,7 +93,18 @@ namespace HzCache
             var acquired = false;
             using (var waitForSemaphore = HzActivities.Source.StartActivityWithCommonTags(HzActivities.Names.WaitForSemaphore, HzActivities.Area.HzCacheMemoryLocker, key: key, async: true))
             {
-                acquired = await semaphore.WaitAsync(timeout, token).ConfigureAwait(false);
+                try
+                {
+                    acquired = await semaphore.WaitAsync(timeout, token).ConfigureAwait(false);
+                }
+                catch (ObjectDisposedException)
+                {
+                    // The MemoryCache evicted and disposed this semaphore between GetSemaphore and WaitAsync.
+                    // Remove the stale entry and retry with a fresh semaphore.
+                    lockCache.Remove(key);
+                    semaphore = GetSemaphore(cacheName, cacheInstanceId, key, logger);
+                    acquired = await semaphore.WaitAsync(timeout, token).ConfigureAwait(false);
+                }
             }
 
             if (acquired)
@@ -136,7 +147,16 @@ namespace HzCache
                    HzActivities.Source.StartActivityWithCommonTags(HzActivities.Names.WaitForSemaphore,
                        HzActivities.Area.HzCacheMemoryLocker, key: key))
             {
-                acquired = semaphore.Wait(timeout, token);
+                try
+                {
+                    acquired = semaphore.Wait(timeout, token);
+                }
+                catch (ObjectDisposedException)
+                {
+                    lockCache.Remove(key);
+                    semaphore = GetSemaphore(cacheName, cacheInstanceId, key, logger);
+                    acquired = semaphore.Wait(timeout, token);
+                }
             }
 
             if (acquired)


### PR DESCRIPTION
## Summary\n\n`HzCacheMemoryLocker` stores `SemaphoreSlim` instances in a `MemoryCache` with 5-minute sliding expiration. The post-eviction callback disposes the semaphore, but there's a race between `GetSemaphore()` returning a reference and `WaitAsync()`/`Wait()` using it — the `MemoryCache` can evict+dispose the semaphore in that window, causing `ObjectDisposedException` to propagate as a fatal \"Could not acquire lock\" error.\n\nFix: catch `ObjectDisposedException` in both `AcquireLockAsync` and `AcquireLock`, remove the stale `lockCache` entry, and retry with a fresh semaphore:\n\n```diff\n+try\n+{\n     acquired = await semaphore.WaitAsync(timeout, token);\n+}\n+catch (ObjectDisposedException)\n+{\n+    lockCache.Remove(key);\n+    semaphore = GetSemaphore(cacheName, cacheInstanceId, key, logger);\n+    acquired = await semaphore.WaitAsync(timeout, token);\n+}\n```\n\nObserved in production Admin on 2026-06-10 (09:07–09:52 UTC, ~2,375 errors). The race was amplified by background serialization failures (`StartUpdateChecksumAndNotify`) causing contention and GC pressure.\n\nJira: [PROD-5987](https://norce.atlassian.net/browse/PROD-5987)">

Link to Devin session: https://app.devin.ai/sessions/3e7c5915fd8640e69f53c7ad184e302d
Requested by: @JoelNygren-Norce

[PROD-5987]: https://norce.atlassian.net/browse/PROD-5987?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ