### PR TITLE
fix: use IsNullOrDefault in RedisBackedHzCache GetOrSet/GetOrSetAsync for value type support

### DIFF
--- a/RedisBackedHzCache/RedisBackedHzCache.cs
+++ b/RedisBackedHzCache/RedisBackedHzCache.cs
@@ -220,7 +220,7 @@ namespace HzCache
         public T GetOrSet<T>(string key, Func<string, T> valueFactory, TimeSpan ttl, long maxMsToWaitForFactory = 10000)
         {
             var value = hzCache.Get<T>(key);
-            if (value != null)
+            if (!HzMemoryCache.IsNullOrDefault(value))
             {
                 return value;
             }

--- a/RedisBackedHzCache/RedisBackedHzCacheAsync.cs
+++ b/RedisBackedHzCache/RedisBackedHzCacheAsync.cs
@@ -57,7 +57,7 @@ namespace HzCache
 
         public async Task<T> GetOrSetAsync<T>(string key, Func<string, Task<T>> valueFactory, TimeSpan ttl, long maxMsToWaitForFactory = 10000)
         {
-            var value = await hzCache.GetAsync<T>(key);
+            var value = await hzCache.GetAsync<T>(key).ConfigureAwait(false);
             if (!HzMemoryCache.IsNullOrDefault(value))
             {
                 return value;
@@ -65,16 +65,16 @@ namespace HzCache
 
             if (options.useRedisAs2ndLevelCache)
             {
-                var redisValue = await GetRedisValueAsync(key);
+                var redisValue = await GetRedisValueAsync(key).ConfigureAwait(false);
                 if (!redisValue.IsNull)
                 {
-                    var ttlValue = await TTLValue.FromRedisValueAsync<T>(Encoding.ASCII.GetBytes(redisValue.ToString()));
+                    var ttlValue = await TTLValue.FromRedisValueAsync<T>(Encoding.ASCII.GetBytes(redisValue.ToString())).ConfigureAwait(false);
                     hzCache.SetRaw(key, ttlValue);
                     return (T)ttlValue.value;
                 }
             }
 
-            return await hzCache.GetOrSetAsync(key, valueFactory, ttl, maxMsToWaitForFactory);
+            return await hzCache.GetOrSetAsync(key, valueFactory, ttl, maxMsToWaitForFactory).ConfigureAwait(false);
         }
 
         public Task<IList<T>> GetOrSetBatchAsync<T>(IList<string> keys, Func<IList<string>, Task<List<KeyValuePair<string, T>>>> valueFactory)

--- a/RedisBackedHzCache/RedisBackedHzCacheAsync.cs
+++ b/RedisBackedHzCache/RedisBackedHzCacheAsync.cs
@@ -58,7 +58,7 @@ namespace HzCache
         public async Task<T> GetOrSetAsync<T>(string key, Func<string, Task<T>> valueFactory, TimeSpan ttl, long maxMsToWaitForFactory = 10000)
         {
             var value = await hzCache.GetAsync<T>(key);
-            if (value != null)
+            if (!HzMemoryCache.IsNullOrDefault(value))
             {
                 return value;
             }

--- a/UnitTests/IntegrationTests.cs
+++ b/UnitTests/IntegrationTests.cs
@@ -308,6 +308,71 @@ namespace UnitTests
 
         [TestMethod]
         [TestCategory("Integration")]
+        public async Task TestRedisGetOrSet_ValueType_CallsFactory()
+        {
+            // Arrange
+            var c1 = new RedisBackedHzCache(
+                new RedisBackedHzCacheOptions { redisConnectionString = ConnectionString, applicationCachePrefix = "test", instanceId = "c1", useRedisAs2ndLevelCache = false });
+            var factoryCalled = false;
+
+            // Act
+            var result = c1.GetOrSet("int-key", _ =>
+            {
+                factoryCalled = true;
+                return 42;
+            }, TimeSpan.FromMinutes(1));
+
+            // Assert
+            Assert.IsTrue(factoryCalled, "Factory should be called on cache miss for value types");
+            Assert.AreEqual(42, result);
+            await c1.RemoveAsync("int-key");
+        }
+
+        [TestMethod]
+        [TestCategory("Integration")]
+        public async Task TestRedisGetOrSetAsync_ValueType_CallsFactory()
+        {
+            // Arrange
+            var c1 = new RedisBackedHzCache(
+                new RedisBackedHzCacheOptions { redisConnectionString = ConnectionString, applicationCachePrefix = "test", instanceId = "c1", useRedisAs2ndLevelCache = false });
+            var factoryCalled = false;
+
+            // Act
+            var result = await c1.GetOrSetAsync("int-key-async", _ =>
+            {
+                factoryCalled = true;
+                return Task.FromResult(42);
+            }, TimeSpan.FromMinutes(1));
+
+            // Assert
+            Assert.IsTrue(factoryCalled, "Factory should be called on cache miss for value types");
+            Assert.AreEqual(42, result);
+            await c1.RemoveAsync("int-key-async");
+        }
+
+        [TestMethod]
+        [TestCategory("Integration")]
+        public async Task TestRedisGetOrSetAsync_ValueType_ReturnsCachedValue()
+        {
+            // Arrange
+            var c1 = new RedisBackedHzCache(
+                new RedisBackedHzCacheOptions { redisConnectionString = ConnectionString, applicationCachePrefix = "test", instanceId = "c1", useRedisAs2ndLevelCache = false });
+            await c1.GetOrSetAsync("int-cached", _ => Task.FromResult(42), TimeSpan.FromMinutes(1));
+
+            // Act — second call should return cached value, not call factory
+            var result = await c1.GetOrSetAsync("int-cached", _ =>
+            {
+                Assert.Fail("Factory should not be called when value is already cached");
+                return Task.FromResult(0);
+            }, TimeSpan.FromMinutes(1));
+
+            // Assert
+            Assert.AreEqual(42, result);
+            await c1.RemoveAsync("int-cached");
+        }
+
+        [TestMethod]
+        [TestCategory("Integration")]
         public async Task TestRedisBackplaneDelete()
         {
             var redis = ConnectionMultiplexer.Connect(ConnectionString);


### PR DESCRIPTION
## Summary

The 0.0.17 early-return optimization in `GetOrSet<T>` / `GetOrSetAsync<T>` used `value != null` to detect cache hits. For non-nullable value types (`int`, `bool`, etc.), `default(T)` boxes to a non-null object, so the check always returned `true` on cache miss — returning `default(T)` **without ever calling the factory**.

This broke `commerce-admin` where `GetOrSetAsync<int>` caches `Application.HostClientId`: the factory was never invoked, `0` was returned instead of the real client ID, producing `"Unknown application id 1"` errors on every request.

**Fix:** Replace `value != null` with `HzMemoryCache.IsNullOrDefault(value)` — the same check the inner `HzMemoryCache.GetOrSet` already uses.

```diff
- if (value != null)
+ if (!HzMemoryCache.IsNullOrDefault(value))
```

Three integration tests added covering: sync factory call, async factory call, and cached-value reuse — all for `int` (value type).

Link to Devin session: https://app.devin.ai/sessions/05ffe056c1f549819e082a624b536749
Requested by: @JoelNygren-Norce